### PR TITLE
Handle missing GPS metadata in uploaded images

### DIFF
--- a/tagscript.js
+++ b/tagscript.js
@@ -45,17 +45,8 @@ function computeTimeInterpolatedColor(start_ms,end_ms,time_ms) {
 }
 
 // It is possible this accessToken will someday reach a limit. We recommend you change it if that occurs.
-<<<<<<< HEAD
-=======
-const MAPBOXGL_ACCESSTOKEN = "";
->>>>>>> 637ca31 (updates)
 
-<<<<<<< HEAD
-const MAPBOXGL_ACCESSTOKEN =
-      "";
-=======
 const MAPBOXGL_ACCESSTOKEN = "";
->>>>>>> f299eed (updates)
 
 const checkForAppInDatabase = (appName) => {
   return new Promise((resolve) => {
@@ -243,6 +234,15 @@ async function createPhotoUploadTag(file, tags, username, color) {
   //  var tagId = "geotag" + tagnum;
   // This tshould actually from the tags!
   // Hopefully this is a UTC
+  if (
+  !tags.GPSLatitude ||
+  !tags.GPSLongitude ||
+  !tags.GPSLongitudeRef
+) {
+  console.warn("Image has no GPS metadata");
+  alert("This image does not contain geolocation information.");
+  return;
+}
   var lat = parseFloat(tags.GPSLatitude.description);
 
   // note: By convention, East longitude is positive


### PR DESCRIPTION
This PR fixes Issue #23.

Changes made:
- Added validation for missing GPS metadata fields before accessing GPSLatitude and GPSLongitude.
- Prevents application crashes when an uploaded image does not contain geolocation information.
- Displays a message to the user when GPS metadata is missing.

Testing:
- Verified that geotagged images still upload and appear on the map.
- Verified that images without GPS metadata no longer crash the application