### PR TITLE
Display original filename in marker popup

### DIFF
--- a/tagscript.js
+++ b/tagscript.js
@@ -37,7 +37,7 @@ const USE_LOCAL_STORAGE = false;
 // This will actually work with units other than ms,
 // so long as it is consistent.
 // I don't know how to handler outside-of-range problems.
-function computeTimeInterpolatedColor(start_ms,end_ms,time_ms) {
+function computeTimeInterpolatedColor(start_ms, end_ms, time_ms) {
   const duration_ms = end_ms - start_ms;
   const fraction = (time_ms - start_ms) / (duration_ms);
   const interpolated_color = d3.interpolateRdYlBu(fraction);
@@ -64,7 +64,7 @@ const checkForAppInDatabase = (appName) => {
 };
 
 function writeTag(
-    tagId,
+  tagId,
   lat,
   lon,
   color,
@@ -83,8 +83,8 @@ function writeTag(
       latitude: lat,
       longitude: lon,
       color: color,
-        //      message: message,
-        message: "test message",
+      //      message: message,
+      message: "test message",
       date: d.toUTCString(),
       filepath: filepath,
     },
@@ -93,10 +93,10 @@ function writeTag(
   //SERVER WRITE - POST, CAN ONLY GET 'GET' TO WORK
 
   // now I also place this tag in localStorage
-    //  writeTagLS(appname,obj);
+  //  writeTagLS(appname,obj);
 
-    console.log("obj:",obj);
-    console.log(JSON.stringify(obj));
+  console.log("obj:", obj);
+  console.log(JSON.stringify(obj));
   $.ajax({
     type: "GET",
     url: "writeTag",
@@ -201,7 +201,7 @@ function getLocation(color) {
       var options = { enableHighAccuracy: false, timeout: 10000 };
       navigator.geolocation.getCurrentPosition(
         (position) =>
-        showPositionOnPage(position, color, "current location", "-current"),
+          showPositionOnPage(position, color, "current location", "-current"),
         error,
         options
       );
@@ -213,8 +213,8 @@ function getLocation(color) {
   }
 }
 
-function ExifDecodeTime(timeString,offset) {
-  var mom = moment.utc(timeString,'YYYY:MM:DD hh:mm:ss');
+function ExifDecodeTime(timeString, offset) {
+  var mom = moment.utc(timeString, 'YYYY:MM:DD hh:mm:ss');
   mom.utcOffset(offset);
   var e_ms = mom.valueOf();
   if (mom.isValid())
@@ -227,26 +227,26 @@ function ExifDecodeTime(timeString,offset) {
 // we may use interplated color when we render this.
 async function createPhotoUploadTag(file, tags, username, color) {
   // This should really come from the GUI somehow
-    const title = "My file";
-    const form = new FormData();
-    const filename = file.name;
-    form.append("title", title);
-    form.append("file", file);
-    form.append("filename", filename);
-    console.log("tags",tags);
-    //  var tagnum = highest_num + 1;
-    //  var tagId = "geotag" + tagnum;
-    // This tshould actually from the tags!
-    // Hopefully this is a UTC
-    if (
-        !tags.GPSLatitude ||
-            !tags.GPSLongitude ||
-            !tags.GPSLongitudeRef
-    ) {
-        console.warn("Image has no GPS metadata");
-        alert("This image does not contain geolocation information.");
-        return;
-    }
+  const title = "My file";
+  const form = new FormData();
+  const filename = file.name;
+  form.append("title", title);
+  form.append("file", file);
+  form.append("filename", filename);
+  console.log("tags", tags);
+  //  var tagnum = highest_num + 1;
+  //  var tagId = "geotag" + tagnum;
+  // This tshould actually from the tags!
+  // Hopefully this is a UTC
+  if (
+    !tags.GPSLatitude ||
+    !tags.GPSLongitude ||
+    !tags.GPSLongitudeRef
+  ) {
+    console.warn("Image has no GPS metadata");
+    alert("This image does not contain geolocation information.");
+    return;
+  }
   var lat = parseFloat(tags.GPSLatitude.description);
 
   // note: By convention, East longitude is positive
@@ -262,22 +262,22 @@ async function createPhotoUploadTag(file, tags, username, color) {
   var DateTime = tags.DateTime ? tags.DateTime.value[0] : null;
   var mainTime = DateTimeDigitized || DateTimeOriginal || DateTime;
   if (!mainTime) {
-  alert("This image has no date/time information.");
-  return;
-}
+    alert("This image has no date/time information.");
+    return;
+  }
   // NOTE: This appears to be the EXIF format, although even
   // my phone appaears use different formats, so we have to wrap this
   // in a function and use some heurstics...
 
   var offsetTime = tags.OffsetTime ? tags.OffsetTime.value[0] : "+00:00";
-  var e_ms = ExifDecodeTime(mainTime,offsetTime);
-  var mainTimeUTC = moment.unix(e_ms/1000).utc().toString();
+  var e_ms = ExifDecodeTime(mainTime, offsetTime);
+  var mainTimeUTC = moment.unix(e_ms / 1000).utc().toString();
 
 
   // The "filename" here is raw from an upload in this
   // code. We will turn it into a url (relative in this case)
   // by prepending "/uploads"
-  var url = "uploads/"+filename;
+  var url = "uploads/" + filename;
   var safeTagId = url.replace(/[./#$[\]]/g, "_");
   var obj = {
     appname: GLOBAL_APPNAME ? GLOBAL_APPNAME : "abc",
@@ -295,21 +295,21 @@ async function createPhotoUploadTag(file, tags, username, color) {
   };
   form.append("obj", JSON.stringify(obj));
 
-    if (USE_LOCAL_STORAGE) {
-        writeTagLS(GLOBAL_APPNAME,obj);
-    } else {
-        writeTag(
-            safeTagId,
-            lat,
-            lon,
-            color,
-            message,
-            username,
-            // Warning, this is dubious
-            obj.appname,
-            url
-        );
-    }
+  if (USE_LOCAL_STORAGE) {
+    writeTagLS(GLOBAL_APPNAME, obj);
+  } else {
+    writeTag(
+      safeTagId,
+      lat,
+      lon,
+      color,
+      message,
+      username,
+      // Warning, this is dubious
+      obj.appname,
+      url
+    );
+  }
 
   $.ajax({
     method: "POST",
@@ -328,8 +328,8 @@ async function createPhotoUploadTag(file, tags, username, color) {
       adjust_global_times(mainTime);
       var filepath = url;
       const interpolated_color =
-            computeTimeInterpolatedColor(GLOBAL_START,GLOBAL_END,e_ms);
-      showPositionOnPage(position, interpolated_color, filepath,  filepath);
+        computeTimeInterpolatedColor(GLOBAL_START, GLOBAL_END, e_ms);
+      showPositionOnPage(position, interpolated_color, filepath, filepath);
     })
     .fail((error) => console.log(error));
 }
@@ -349,10 +349,10 @@ async function createPhotoUploadTag(file, tags, username, color) {
 function showPositionOnPage(position, color, message, filepath) {
   if (color != "black") {
     var x = (document.getElementById("demo").innerHTML =
-             "Latitude: " +
-             position.coords.latitude +
-             "<br>Longitude: " +
-             position.coords.longitude);
+      "Latitude: " +
+      position.coords.latitude +
+      "<br>Longitude: " +
+      position.coords.longitude);
   }
   var lonDec = position.coords.longitude;
   var latDec = position.coords.latitude;
@@ -368,19 +368,19 @@ function showPositionOnPage(position, color, message, filepath) {
 var GLOBAL_ADDED_LAYERS = [];
 // we will only one popup at a time.
 var GLOBAL_POPUP = null;
-function hideBasedOnTimes(start_ms,end_ms) {
+function hideBasedOnTimes(start_ms, end_ms) {
   var layers = GLOBAL_ADDED_LAYERS;
   // now interate over sources, checking time!!
   for (const l in layers) {
     const layer = layers[l];
     const layer_ms = moment(layer.timestamp).valueOf();
     const v = (layer_ms >= start_ms && layer_ms <= end_ms)
-          ? 'visible'
-          : 'none';
+      ? 'visible'
+      : 'none';
     const official_layer = map.getLayer(layer.id);
     map.setLayoutProperty(official_layer.id,
-                          'visibility',
-                          v);
+      'visibility',
+      v);
   }
 }
 function removeAllLayers() {
@@ -427,8 +427,8 @@ function showLngLatOnMap(lonDec, latDec, color, message, filepath, timestamp) {
             coordinates: [lonDec, latDec],
           },
           properties: {
-          description: "<p>" + message + "</p>",
-          color: color,
+            description: "<p>" + message + "</p>",
+            color: color,
           },
         },
       ],
@@ -446,8 +446,8 @@ function showLngLatOnMap(lonDec, latDec, color, message, filepath, timestamp) {
               coordinates: [lonDec, latDec],
             },
             properties: {
-            description: "<p>" + message + "</p>",
-            color: color,
+              description: "<p>" + message + "</p>",
+              color: color,
             },
           },
         ],
@@ -477,12 +477,25 @@ function showLngLatOnMap(lonDec, latDec, color, message, filepath, timestamp) {
 
       // We will now add a direct link to the photo to the HTML in the popup,
       // and then try to add a nice thumbnail.
-      var fullHTML = `time: ${timestamp} <a href='${filepath}' target='_blank'> window</a> <div> <a href='${filepath}' download>download</a> </div>
+      const filename = filepath.split("/").pop();
+      //const filename = filepath.split("/").pop();
+
+      var fullHTML = `
+<b>Filename:</b> ${filename}<br>
+<b>Time:</b> ${timestamp}<br>
+<a href='${filepath}' target='_blank'>window</a>
+
+<div>
+  <a href='${filepath}' download>download</a>
+</div>
+
 <img src="./${filepath}" alt="${filepath}" height="300">
+
 <div id="desc-display">
   <p><b>Description:</b> ${e.features[0].properties.description || "No description added"}</p>
   <button onclick="editDescription('${filepath}')">Edit</button>
 </div>
+
 <div id="desc-edit-${filepath}" style="display:none">
   <textarea id="desc-text-${filepath}" rows="2" cols="30">${e.features[0].properties.Description || ""}</textarea>
   <button onclick="saveDescription('${filepath}')">Save</button>
@@ -520,12 +533,12 @@ function saveDescription(filepath) {
       tagId: filepath.replace(/[./#$[\]]/g, "_"),
       description: newDescription
     },
-    success: function(result) {
+    success: function (result) {
       document.getElementById("desc-display").querySelector("p").innerHTML = "<b>Description:</b> " + newDescription;
       document.getElementById("desc-display").style.display = "block";
       document.getElementById("desc-edit-" + filepath).style.display = "none";
     },
-    error: function(e) {
+    error: function (e) {
       console.log("ERROR: ", e);
     }
   });
@@ -539,26 +552,26 @@ async function loadToken() {
 }
 
 function initMap(appname) {
-// It is possible this accessToken will someday reach a limit. We recommend you change it if that occurs.
-let MAPBOXGL_ACCESSTOKEN;
+  // It is possible this accessToken will someday reach a limit. We recommend you change it if that occurs.
+  let MAPBOXGL_ACCESSTOKEN;
 
-const GRAB_MAPBOX_TOKEN = loadToken();
-  GRAB_MAPBOX_TOKEN.then(function(result) {
-  MAPBOXGL_ACCESSTOKEN = result;
+  const GRAB_MAPBOX_TOKEN = loadToken();
+  GRAB_MAPBOX_TOKEN.then(function (result) {
+    MAPBOXGL_ACCESSTOKEN = "pk.eyJ1Ijoicm9iZXJ0bHJlYWQiLCJhIjoiY21wbzFwbjZjMDFjczJxcHZjNjY5bzF1cSJ9.vQ1VeDFxaikHIkMSb0kpqA";
 
-  mapboxgl.accessToken = MAPBOXGL_ACCESSTOKEN;
+    mapboxgl.accessToken = MAPBOXGL_ACCESSTOKEN;
 
-  map = new mapboxgl.Map({
-    container: "map",
-    style: "mapbox://styles/mapbox/light-v9",
-    center: [-96, 37.8],
-    zoom: 3,
-  });
+    map = new mapboxgl.Map({
+      container: "map",
+      style: "mapbox://styles/mapbox/light-v9",
+      center: [-96, 37.8],
+      zoom: 3,
+    });
 
-    map.on("load",() => ( USE_LOCAL_STORAGE ? refreshAllDataLS(appname)
-                          : refreshAllDataDB(appname)))
+    map.on("load", () => (USE_LOCAL_STORAGE ? refreshAllDataLS(appname)
+      : refreshAllDataDB(appname)))
   }
-                        );
+  );
 }
 
 
@@ -570,9 +583,9 @@ function removeCurrentLoc() {
   }
 }
 
-function putAllDataIntoLocalStorage(appname,result) {
+function putAllDataIntoLocalStorage(appname, result) {
   window.localStorage.setItem(appname,
-                              JSON.stringify(result));
+    JSON.stringify(result));
 }
 
 function getAllDataFromLocalStorage(appname) {
@@ -585,19 +598,19 @@ function reportLS(appname) {
   console.log(obj);
 }
 
-function writeTagLS(appname,obj) {
-    var superSubject = getAllDataFromLocalStorage(appname);
+function writeTagLS(appname, obj) {
+  var superSubject = getAllDataFromLocalStorage(appname);
   console.log("superSubject");
-    console.log(superSubject);
-    console.log("obj",obj);
-    // WARNING! This is a bug...
-    if (!superSubject) {
-        superSubject = {};
-        superSubject[obj.tagId] = obj;
-    } else {
-        superSubject[obj.tagId] = obj;
-    }
-  putAllDataIntoLocalStorage(appname,superSubject);
+  console.log(superSubject);
+  console.log("obj", obj);
+  // WARNING! This is a bug...
+  if (!superSubject) {
+    superSubject = {};
+    superSubject[obj.tagId] = obj;
+  } else {
+    superSubject[obj.tagId] = obj;
+  }
+  putAllDataIntoLocalStorage(appname, superSubject);
   reportLS(appname);
 }
 
@@ -611,10 +624,10 @@ function renderMarkers(v) {
   }
   for (const prop in v) {
     gt = v[prop];
-      //    gti = gt.taginfo;
-      gti = gt;
+    //    gti = gt.taginfo;
+    gti = gt;
     const time_ms = moment.utc(gti.date).valueOf();
-    const color = computeTimeInterpolatedColor(GLOBAL_START,GLOBAL_END,time_ms);
+    const color = computeTimeInterpolatedColor(GLOBAL_START, GLOBAL_END, time_ms);
     // Note: gt.color may remain of interest, but I am not currently rendering it.
     showLngLatOnMap(
       gti.longitude,
@@ -659,7 +672,7 @@ function refreshAllDataDB(appname) {
           const n = parseInt(prop.substring("geotag".length));
           gt = v[prop];
           const time_ms = moment.utc(gt.date).valueOf();
-          const color = computeTimeInterpolatedColor(GLOBAL_START,GLOBAL_END,time_ms);
+          const color = computeTimeInterpolatedColor(GLOBAL_START, GLOBAL_END, time_ms);
           // Note: gt.color may remain of interest, but I am not currently rendering it.
           showLngLatOnMap(
             gt.longitude,
@@ -700,7 +713,7 @@ class Event {
     const concatenation = this.contentHash + "|" + this.uploader + "|" + this.timeHash;
     return cryptoHash(concatenation);
   }
-  constructor(url, content, uploader,latitude, longitude, eventDate) {
+  constructor(url, content, uploader, latitude, longitude, eventDate) {
     this.url = url;
     // In actuality, we need to use the content to compute a hash...
     this.contentHash = this.hashContent(content);

--- a/tagscript.js
+++ b/tagscript.js
@@ -557,7 +557,7 @@ function initMap(appname) {
 
   const GRAB_MAPBOX_TOKEN = loadToken();
   GRAB_MAPBOX_TOKEN.then(function (result) {
-    MAPBOXGL_ACCESSTOKEN = "pk.eyJ1Ijoicm9iZXJ0bHJlYWQiLCJhIjoiY21wbzFwbjZjMDFjczJxcHZjNjY5bzF1cSJ9.vQ1VeDFxaikHIkMSb0kpqA";
+    MAPBOXGL_ACCESSTOKEN = result;
 
     mapboxgl.accessToken = MAPBOXGL_ACCESSTOKEN;
 

--- a/tagscript.js
+++ b/tagscript.js
@@ -478,7 +478,6 @@ function showLngLatOnMap(lonDec, latDec, color, message, filepath, timestamp) {
       // We will now add a direct link to the photo to the HTML in the popup,
       // and then try to add a nice thumbnail.
       const filename = filepath.split("/").pop();
-      //const filename = filepath.split("/").pop();
 
       var fullHTML = `
 <b>Filename:</b> ${filename}<br>


### PR DESCRIPTION
This PR addresses Issue #12.

Changes made:
- Display the original uploaded filename in the marker popup.
- Extract the filename from the stored file path using split("/").pop().
- Preserve the existing popup layout and functionality.

Testing:
- Verified that uploaded images display the original filename in the popup.
- Verified that existing image preview, window, and download links continue to work.
